### PR TITLE
Improve theme handling and cleanup data layer

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,14 @@ const state = { route: '/dashboard', cal: { year: new Date().getFullYear(), mont
 const qs = (sel, el=document)=> el.querySelector(sel);
 const qsa = (sel, el=document)=> [...el.querySelectorAll(sel)];
 
+const colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+function applyTheme(mode){
+  document.documentElement.classList.remove('light');
+  if (mode === 'light') document.documentElement.classList.add('light');
+  if (mode === 'auto'){ if (!colorScheme.matches) document.documentElement.classList.add('light'); }
+}
+
 async function main(){
   await store.init();
   initTheme();
@@ -23,17 +31,16 @@ function updateVersion(){
 }
 
 function initTheme(){
-  const t = store.settings.theme || 'auto';
-  applyTheme(t);
-  qs('#themeToggle').addEventListener('click', async ()=>{
-    const next = document.documentElement.classList.contains('light') ? 'auto' : 'light';
-    applyTheme(next);
-    await store.saveSettings({theme: next});
+  let mode = store.settings.theme || 'auto';
+  applyTheme(mode);
+  colorScheme.addEventListener('change', ()=>{
+    if (mode === 'auto') applyTheme('auto');
   });
-  function applyTheme(mode){
-    document.documentElement.classList.remove('light');
-    if (mode==='light') document.documentElement.classList.add('light');
-  }
+  qs('#themeToggle').addEventListener('click', async ()=>{
+    mode = mode === 'auto' ? 'light' : mode === 'light' ? 'dark' : 'auto';
+    applyTheme(mode);
+    await store.saveSettings({theme: mode});
+  });
 }
 
 function bindNav(){
@@ -248,6 +255,7 @@ function renderSettings(root){
       notifyTime: form.elements.notifyTime.value
     };
     await store.saveSettings(data);
+    applyTheme(data.theme);
     if (data.useNotifications) requestNotifyPermission();
   });
   qs('[data-action="backup"]', tpl).addEventListener('click', async ()=>{

--- a/js/db.js
+++ b/js/db.js
@@ -1,5 +1,5 @@
 export class DB {
-  constructor(name = 'cactolog', version = 1){
+  constructor(name = 'cactolog', version = 2){
     this.name = name; this.version = version; this.db = null;
   }
   async open(){
@@ -8,6 +8,7 @@ export class DB {
       const req = indexedDB.open(this.name, this.version);
       req.onupgradeneeded = ()=>{
         const db = req.result;
+        if (db.objectStoreNames.contains('photos')) db.deleteObjectStore('photos');
         if (!db.objectStoreNames.contains('plants')){
           const s = db.createObjectStore('plants', { keyPath: 'id' });
           s.createIndex('by_name','name',{unique:false});
@@ -17,10 +18,6 @@ export class DB {
           const s = db.createObjectStore('activities', { keyPath: 'id' });
           s.createIndex('by_plant','plantId',{unique:false});
           s.createIndex('by_date','date',{unique:false});
-        }
-        if (!db.objectStoreNames.contains('photos')){
-          const s = db.createObjectStore('photos', { keyPath: 'id' });
-          s.createIndex('by_plant','plantId',{unique:false});
         }
         if (!db.objectStoreNames.contains('settings')){
           db.createObjectStore('settings');

--- a/js/store.js
+++ b/js/store.js
@@ -3,7 +3,7 @@ import { uid, toISODate, addDays, diffDays } from './utils.js';
 
 export class Store {
   constructor(){
-    this.db = new DB('cactolog', 1);
+    this.db = new DB('cactolog', 2);
     this.cache = { plants: [], activities: [], settings: {} };
   }
   async init(){
@@ -37,7 +37,6 @@ export class Store {
   async deletePlant(id){
     await this.db.delete('plants', id);
     this.cache.plants = this.cache.plants.filter(p=>p.id!==id);
-    // also delete related photos and activities
     const rel = this.cache.activities.filter(a=>a.plantId===id).map(a=>a.id);
     for (const aid of rel) await this.db.delete('activities', aid);
     this.cache.activities = this.cache.activities.filter(a=>a.plantId!==id);

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cactolog-v1';
+const CACHE_NAME = 'cactolog-v2';
 const ASSETS = [
   
   'index.html',
@@ -21,17 +21,18 @@ self.addEventListener('activate', (event)=>{
 });
 self.addEventListener('fetch', (event)=>{
   const req = event.request;
+  if (req.method !== 'GET') return;
   event.respondWith(
     caches.match(req).then(cached => cached || fetch(req).then(res=>{
-      // cache runtime GETs for same-origin
-      if (req.method==='GET' && new URL(req.url).origin === location.origin){
+      if (res.ok && new URL(req.url).origin === location.origin){
         const copy = res.clone();
         caches.open(CACHE_NAME).then(c=> c.put(req, copy));
       }
       return res;
     }).catch(()=>{
       if (req.destination === 'image') return caches.match('assets/placeholder.jpg');
-      return caches.match('index.html');
+      if (req.mode === 'navigate') return caches.match('index.html');
+      return Response.error();
     }))
   );
 });


### PR DESCRIPTION
## Summary
- Expand theme system to respect system preference and allow cycling through auto/light/dark modes
- Remove unused `photos` object store and bump IndexedDB version
- Refine service worker caching with navigation-only HTML fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bca811dca4832b98f9cb4e4c0e8d64