### PR TITLE
feat: add offline status indicator

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,6 +45,8 @@ body{
 }
 .brand{ font-size:1.1rem; margin:0; letter-spacing:.2px }
 .header-actions{ margin-left:auto; display:flex; gap:.5rem; align-items:center }
+.status-dot{ width:10px; height:10px; border-radius:50%; background:var(--ok); }
+.status-dot.offline{ background:var(--bad); }
 .icon-btn, .btn, .primary-btn{
   display:inline-flex; align-items:center; justify-content:center; gap:.5rem;
   padding:.5rem .75rem; border:1px solid var(--border); background:var(--card); color:var(--text);

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       <button id="themeToggle" class="icon-btn" aria-label="Toggle theme" title="Theme">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1zm0 14a5 5 0 1 0 0-10 5 5 0 0 0 0 10zm9-5a1 1 0 0 1-1 1h-2a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zM6 12a1 1 0 0 1-1 1H3a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zm11.657 6.657a1 1 0 0 1-1.414 1.414l-1.414-1.414a1 1 0 1 1 1.414-1.414l1.414 1.414zM7.757 7.757a1 1 0 0 1-1.414-1.414L7.757 4.93a1 1 0 1 1 1.414 1.414L7.757 7.757zm8.486-2.828 1.414-1.414a1 1 0 1 1 1.414 1.414l-1.414 1.414A1 1 0 0 1 16.243 4.93zM4.93 16.243a1 1 0 1 1 1.414 1.414L4.93 19.071a1 1 0 0 1-1.414-1.414l1.414-1.414z"/></svg>
       </button>
+      <span id="netStatus" class="status-dot" aria-label="Online" title="Online"></span>
       <button id="installBtn" class="primary-btn small" hidden>Install</button>
     </div>
   </header>

--- a/js/app.js
+++ b/js/app.js
@@ -20,6 +20,7 @@ async function main(){
   registerSW();
   bindChromeInstall();
   bindNav();
+  bindNetworkStatus();
   routeTo(location.hash.replace('#','') || '/dashboard');
   updateVersion();
   if (store.settings.useNotifications) requestNotifyPermission();
@@ -369,6 +370,20 @@ function bindChromeInstall(){
     btn.hidden = true;
     deferredPrompt = null;
   });
+}
+
+function bindNetworkStatus(){
+  const dot = qs('#netStatus');
+  if (!dot) return;
+  const update = ()=>{
+    const online = navigator.onLine;
+    dot.classList.toggle('offline', !online);
+    dot.setAttribute('aria-label', online ? 'Online' : 'Offline');
+    dot.title = online ? 'Online' : 'Offline';
+  };
+  window.addEventListener('online', update);
+  window.addEventListener('offline', update);
+  update();
 }
 
 function escapeHTML(str=''){


### PR DESCRIPTION
## Summary
- show network connectivity with a status dot in header
- track online/offline events to update indicator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5b0fffe20832b9098a1231b87980a