### PR TITLE
feat: add plant sorting options

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,10 @@
             <option value="succulent">Succulent</option>
             <option value="foliage">Foliage</option>
           </select>
+          <select id="sortBy" aria-label="Sort plants">
+            <option value="name">Name</option>
+            <option value="nextWaterDate">Next watering</option>
+          </select>
           <button class="primary-btn" data-action="add-plant">Add plant</button>
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -130,7 +130,8 @@ function renderPlants(root){
   function draw(){
     const search = qs('#plantSearch', root)?.value || '';
     const type = qs('#filterType', root)?.value || '';
-    const arr = store.listPlants({ search, type });
+    const sort = qs('#sortBy', root)?.value || 'name';
+    const arr = store.listPlants({ search, type, sort });
     listEl.innerHTML = '';
     if (!arr.length){ listEl.innerHTML = `<div class="empty">No plants yet. Add one.</div>`; return; }
     for (const p of arr){
@@ -164,7 +165,7 @@ function renderPlants(root){
   }
   qs('[data-action="add-plant"]', tpl).addEventListener('click', ()=> openPlantDialog());
   tpl.addEventListener('input', (e)=>{
-    if (e.target.id === 'plantSearch' || e.target.id === 'filterType') draw();
+    if (['plantSearch', 'filterType', 'sortBy'].includes(e.target.id)) draw();
   });
   root.appendChild(tpl);
   draw();

--- a/js/store.js
+++ b/js/store.js
@@ -1,5 +1,5 @@
 import { DB } from './db.js';
-import { uid, toISODate, addDays, diffDays } from './utils.js';
+import { uid, toISODate, addDays, diffDays, sortBy } from './utils.js';
 
 export class Store {
   constructor(){
@@ -60,14 +60,17 @@ export class Store {
     }
     return act;
   }
-  listPlants({ search='', type='' }={}){
+  listPlants({ search='', type='', sort='name' }={}){
     const s = search.trim().toLowerCase();
-    return this.cache.plants.filter(p=>{
+    let arr = this.cache.plants.filter(p=>{
       const matchType = type ? p.type === type : true;
       if (!s) return matchType;
       const hay = [p.name, p.species, p.tags].filter(Boolean).join(' ').toLowerCase();
       return matchType && hay.includes(s);
     });
+    if (sort === 'nextWaterDate') arr = sortBy(arr, 'nextWaterDate');
+    else arr = sortBy(arr, 'name');
+    return arr;
   }
   duePlants(onDate = toISODate(new Date())){
     return this.cache.plants

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cactolog-v2';
+const CACHE_NAME = 'cactolog-v3';
 const ASSETS = [
   
   'index.html',


### PR DESCRIPTION
## Summary
- add UI control to sort plant list by name or upcoming watering
- implement sorting in store and respect selection in plant view
- bump service worker cache version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5b0fffe20832b9098a1231b87980a